### PR TITLE
chore: update template to only run on main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,8 @@ name: Mirror to Radicle
 # Controls when the workflow will run
 on:
   push:
+    branches:
+      - main
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
I think running job on every push seems bit redundant, perhaps it's best to do it only on main branch by default ?